### PR TITLE
fix: handle zero times in circuit breaker metrics

### DIFF
--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -464,6 +464,16 @@ func (cb *CircuitBreaker) Metrics() map[string]interface{} {
 	cb.mutex.RLock()
 	defer cb.mutex.RUnlock()
 
+	lastFailure := "never"
+	if !cb.lastFailTime.IsZero() {
+		lastFailure = cb.lastFailTime.Format(time.RFC3339)
+	}
+
+	lastStateChange := "never"
+	if !cb.lastStateChange.IsZero() {
+		lastStateChange = cb.lastStateChange.Format(time.RFC3339)
+	}
+
 	return map[string]interface{}{
 		"name":             cb.name,
 		"state":            cb.state.String(),
@@ -476,8 +486,8 @@ func (cb *CircuitBreaker) Metrics() map[string]interface{} {
 		"max_failures":     cb.maxFailures,
 		"timeout_seconds":  cb.timeout.Seconds(),
 		"max_requests":     cb.maxRequests,
-		"last_failure":     cb.lastFailTime.Format(time.RFC3339),
-		"last_state_change": cb.lastStateChange.Format(time.RFC3339),
+		"last_failure":     lastFailure,
+		"last_state_change": lastStateChange,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #19 - Circuit breaker metrics now properly handle zero times
- Zero times now display as "never" instead of the zero time value

## Changes
Modified the `Metrics()` method in `circuit_breaker.go` to check if `lastFailTime` and `lastStateChange` are zero times before formatting them. If they are zero, the method returns "never" instead of formatting the zero time value.

## Testing
- All existing tests pass
- Manually verified that zero times display as "never" in metrics output
- Tested that non-zero times still display correctly in RFC3339 format